### PR TITLE
Update daily builds / build-from-source page.

### DIFF
--- a/modules/ROOT/pages/download/dev/index.adoc
+++ b/modules/ROOT/pages/download/dev/index.adoc
@@ -30,25 +30,14 @@ download (unsupported) daily development builds.
 
 == Daily builds
 
-Please visit link:https://ci-builds.apache.org/job/Netbeans/job/netbeans-linux/[https://ci-builds.apache.org/job/Netbeans/job/netbeans-linux/] for the daily builds.
+Please visit the link:https://ci-builds.apache.org/job/Netbeans/job/netbeans-linux/lastSuccessfulBuild/artifact/nbbuild/[build server] for daily builds.
 
 == Building from source
 
 You can of course build Apache NetBeans from source. To do so:
 
 . Clone the link:https://github.com/apache/netbeans[https://github.com/apache/netbeans] GitHub repository.
-. Install an LTS release of the Java Development Kit. (JDK 11+)
-. Install Apache Ant 1.10 or greater (link:https://ant.apache.org/[https://ant.apache.org/]).
-. Set or verify that the environment variables JAVA_HOME and ANT_HOME are properly defined.
-
-Once you're all set, enter the `netbeans` directory:
-
-- To build the Apache NetBeans IDE, according to the JDK type `ant build` in the command line or shell of your choice
-- The build will generate a binary zip bundle of the IDE at `./nbbuild/NetBeans-<version-hash>-release.zip`, and you can:
-  ** Extract that zip in a place of your choosing and run `netbeans/bin/netbeans` (or `netbeans/bin/netbeans.exe` on Windows).
-  ** Type `ant tryme` to run the Apache NetBeans IDE directly from the build folder rather than the zip for development purposes.
-
-For details, go here: link:https://cwiki.apache.org/confluence/display/NETBEANS/Development+Environment[https://cwiki.apache.org/confluence/display/NETBEANS/Development+Environment]
+. And follow the link:https://github.com/apache/netbeans?tab=readme-ov-file#requirements[Requirements], link:https://github.com/apache/netbeans?tab=readme-ov-file#building-netbeans[Building NetBeans] and link:https://github.com/apache/netbeans?tab=readme-ov-file#running-netbeans[Running NetBeans] sections of the included README
 
 Now that you have built Apache NetBeans from source you may want to xref:participate/submit-pr.adoc[submit a pull request].
 


### PR DESCRIPTION
 - refer to the included README when possible which is the most up to date document for building NetBeans.
 - update devbuild link to lead to the latest artifact
 
 page -> https://netbeans.apache.org/front/main/download/dev/