### PR TITLE
Add link to Codelerity packages

### DIFF
--- a/modules/ROOT/pages/download/nb28/index.adoc
+++ b/modules/ROOT/pages/download/nb28/index.adoc
@@ -84,6 +84,10 @@ The PGP keys used to sign this release are available link:https://downloads.apac
 
 == Installers and Packages
 
+- link:https://www.codelerity.com/netbeans/[Codelerity packages] - Windows, macOS and
+Linux (.deb / .rpm) built with
+link:https://github.com/apache/netbeans-nbpackage/[NBPackage]. All include a local Temurin JDK
+for the IDE to run on, for a self-contained out-of-the-box experience.
 //- link:https://installers.friendsofapachenetbeans.org/[Friends of Apache NetBeans] - Windows, macOS and
 //Linux (.deb / .rpm) built with link:https://github.com/apache/netbeans-nbpackage/[NBPackage].
 //All include a local JDK runtime for the IDE to run on, for a self-contained out-of-the-box experience.


### PR DESCRIPTION
Given delays in providing the full range of community installers, and because I needed some NB28 packages today, I've published the usual selection at their previous location as a (possibly stopgap) solution.

https://www.codelerity.com/netbeans/

Built in a workflow at https://github.com/codelerity/netbeans-packages