### PR TITLE
replaced NetCat link with link to GH-discussions

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -53,7 +53,7 @@ Subscribe to our xref:community/mailing-lists.adoc[mailing lists], or follow us 
 
 [.card.magenta]
 .icon:arrow-right[] Participate
-See how you can participate by xref:participate/submit-pr.adoc[submitting pull requests], xref:participate/report-issue.adoc[filing issues], or joining the link:https://cwiki.apache.org/confluence/display/NETBEANS/NetCAT[NetCAT] program.
+See how you can participate by xref:participate/submit-pr.adoc[submitting pull requests], xref:participate/report-issue.adoc[filing issues], or joining the link:https://github.com/apache/netbeans/discussions[discussions].
 
 [.card.blue]
 .icon:book[] Learn


### PR DESCRIPTION
Since the NetCat program is not used anymore I think its better to promote the Github discussions page instead.