### PR TITLE
page updates for the NetBeans 29 release

### DIFF
--- a/modules/ROOT/pages/download/archive/index.adoc
+++ b/modules/ROOT/pages/download/archive/index.adoc
@@ -28,6 +28,12 @@
 
 Older Apache NetBeans releases can still be downloaded, but are no longer supported.
 
+== Apache NetBeans 28
+
+Apache NetBeans 28 was released on November 10, 2025
+
+link:https://github.com/apache/netbeans/releases/tag/28[Features, role="button"] xref:download/nb28/index.adoc[Download, role="button success"]
+
 == Apache NetBeans 27
 
 Apache NetBeans 27 was released on August 21, 2025

--- a/modules/ROOT/pages/download/index.adoc
+++ b/modules/ROOT/pages/download/index.adoc
@@ -37,12 +37,12 @@ for important requirements for download pages for Apache projects.
 
 Apache NetBeans is released four times a year. For details, see link:https://cwiki.apache.org/confluence/display/NETBEANS/Release+Schedule[full release schedule].
 
-== Apache NetBeans 28
+== Apache NetBeans 29
 
-Latest version of the IDE, released on November 10, 2025.
+Latest version of the IDE, released on February 23, 2026.
 // TODO date                           ^^^^
 
-xref:download/nb28/index.adoc[Download, role="button success"]
+xref:download/nb29/index.adoc[Download, role="button success"]
 
 == Older releases
 

--- a/modules/ROOT/pages/download/nb29/index.adoc
+++ b/modules/ROOT/pages/download/nb29/index.adoc
@@ -23,23 +23,26 @@ See https://www.apache.org/dev/release-download-pages.html
 for important requirements for download pages for Apache projects.
 
 ////
-= Downloading Apache NetBeans 28
+= Downloading Apache NetBeans 29
 :page-layout: page_noaside
 :page-tags: download
 :jbake-status: published
-:keywords: Apache NetBeans 28 Download
-:description: Apache NetBeans 28 Download
+:keywords: Apache NetBeans 29 Download
+:description: Apache NetBeans 29 Download
 :toc: left
 :toc-title:
 :icons: font
 
 // check version above and follow the TODOs
-:netbeans-version: 28
+:netbeans-version: 29
 // TODO            ^^
 
 // https://infra.apache.org/release-distribution.html#download-links
-:url-download: https://archive.apache.org/dist/netbeans/
-:url-download-keychecksum: https://archive.apache.org/dist/netbeans/
+// TODO base URLs - when archiving, delete the next 2 lines and uncomment the following 2
+:url-download: https://www.apache.org/dyn/closer.lua/netbeans/
+:url-download-keychecksum: https://downloads.apache.org/netbeans/
+// :url-download: https://archive.apache.org/dist/netbeans/
+// :url-download-keychecksum: https://archive.apache.org/dist/netbeans/
 
 //// 
 url-download depends of release status archived or not
@@ -51,7 +54,7 @@ https://archive.apache.org/dist/netbeans/  (//archived)
 https://downloads.apache.org/netbeans/ (//current)
 ////
 
-Apache NetBeans {netbeans-version} was released on November 10, 2025.
+Apache NetBeans {netbeans-version} was released on February 23, 2026.
 // TODO update date                                ^^^^
 
 ////
@@ -86,8 +89,9 @@ Linux (.deb / .rpm) built with
 link:https://github.com/apache/netbeans-nbpackage/[NBPackage]. All include a local Temurin JDK
 for the IDE to run on, for a self-contained out-of-the-box experience.
 //- link:https://installers.friendsofapachenetbeans.org/[Friends of Apache NetBeans] - Windows, macOS and
-//Linux (.deb / .rpm) built with link:https://github.com/apache/netbeans-nbpackage/[NBPackage].
-//All include a local JDK runtime for the IDE to run on, for a self-contained out-of-the-box experience.
+//Linux (.deb / .rpm) built with
+//link:https://github.com/apache/netbeans-nbpackage/[NBPackage]. All include a local Zulu JDK
+//for the IDE to run on, for a self-contained out-of-the-box experience.
 - link:https://snapcraft.io/netbeans[Linux snap package]
 
 IMPORTANT: These installers and packages are provided by various NetBeans committers as a convenience.
@@ -96,15 +100,13 @@ They may include other contents (eg. JDK) under additional license terms.
 
 == Deployment Platforms
 
-Apache NetBeans {netbeans-version} supports running on JDK 25, 21 or 17.
+Apache NetBeans {netbeans-version} supports running on JDK 25, 21 or 17 (with initial support for JDK 26).
 
 TIP: The Runtime JDK NetBeans uses does not influence the JDK range projects can use.
 
 TIP: Use the latest JDK update release for the best experience (see link:https://javaalmanac.io/jdk/[Java Version Almanac]).
 
 == Known Issues
-
-* A bug in uutils (Ubuntu default) does also affect the embedded NetBeans terminal, link:https://github.com/apache/netbeans/issues/8938[#8938]
 
 * NetBeans 23+ does no longer support String Templates, link:https://github.com/apache/netbeans/discussions/7620[more info]
 
@@ -127,8 +129,8 @@ in a directory of your liking.
 As in any other Apache Project, the Apache NetBeans Community approved this release
 through the following voting processes in our xref:community/mailing-lists.adoc[mailing lists]:
 
-- link:https://lists.apache.org/thread/h2nq4g773pglvpmkh00smhps3flfyxyd[PMC vote]
-- link:https://lists.apache.org/thread/l8l1cyy2yv9s30gofocso9j1qt9swk94[PMC vote result]
+- link:https://lists.apache.org/thread/79mb2wpgfqwdp1hh79h3z84ststb65g6[PMC vote]
+- link:https://lists.apache.org/thread/mfnz5l1kvjbwjckshgdf9lhc9bzv9jy2[PMC vote result]
 // TODO update links                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 == Earlier Releases


### PR DESCRIPTION
removes known issues link to https://github.com/apache/netbeans/issues/8938 since uutils had a release