### PR TITLE
Updated references to the historical code respository

### DIFF
--- a/modules/ROOT/pages/about/oracle-transition.adoc
+++ b/modules/ROOT/pages/about/oracle-transition.adoc
@@ -62,7 +62,7 @@ Jaroslav Tulach is hosting a Maven repository with all previous Oracle binaries 
 === Hg mercurial repositories
 
 - Jaroslav Tulach is hosting a clone of the Mercurial repositories at http://source.apidesign.org/hg/netbeans/
-- Emilian Bold's conversion of Mercurial to git is available at https://github.com/emilianbold/netbeans-releases
+- Emilian Bold's conversion of Mercurial to git is available at https://github.com/codelerity/netbeans-releases
 
 
 

--- a/modules/ROOT/pages/download/dev/index.adoc
+++ b/modules/ROOT/pages/download/dev/index.adoc
@@ -50,7 +50,7 @@ This is a list of Apache NetBeans repositories:
 - link:https://github.com/apache/netbeans-website[https://github.com/apache/netbeans-website] This website's repository.
 - link:https://github.com/apache/netbeans-website-cleanup[https://github.com/apache/netbeans-website-cleanup] A repository used to clean up existing documentation from pass:[http://netbeans.org]
 - link:https://github.com/apache/netbeans-tools[https://github.com/apache/netbeans-tools] Tools and facilities in support of the Apache NetBeans project.
-- Emilian Bold has converted the previous Mercurial repository (pass:[http://hg.netbeans.org]) to git, for historical reference, and has kindly uploaded it to GitHub at https://github.com/emilianbold/netbeans-releases. Thanks, Emilian!
+- Emilian Bold has converted the previous Mercurial repository (pass:[http://hg.netbeans.org]) to git, for historical reference, and has kindly uploaded it to GitHub at https://github.com/codelerity/netbeans-releases. Thanks, Emilian!
 
 
 


### PR DESCRIPTION
It appears that the historical repository previously at https://github.com/emilianbold/netbeans-releases has now moved to https://github.com/codelerity/netbeans-releases.